### PR TITLE
[DPE-7504] MySQL slim snap

### DIFF
--- a/.github/.jira_sync_config.yaml
+++ b/.github/.jira_sync_config.yaml
@@ -1,0 +1,22 @@
+# Sync GitHub issues to Jira issues
+
+# Configuration syntax:
+# https://github.com/canonical/gh-jira-sync-bot/blob/main/README.md#client-side-configuration
+settings:
+  # Repository specific settings
+  components: # Jira components that will be added to Jira issue
+    - mysql-vm
+    - snap
+
+  # Settings shared across Data Platform repositories
+  label_mapping:
+    # If the GitHub issue does not have a label in this mapping, the Jira issue will be created as a Bug
+    enhancement: Story
+  jira_project_key: DPE  # https://warthogs.atlassian.net/browse/DPE
+  status_mapping:
+    opened: untriaged
+    closed: done  # GitHub issue closed as completed
+    not_planned: rejected  # GitHub issue closed as not planned
+  add_gh_comment: true
+  sync_description: false
+  sync_comments: false

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,27 @@
+---
+name: Bug report
+about: File a bug report
+labels: bug
+
+---
+
+<!-- Thank you for submitting a bug report! All fields are required unless marked optional. -->
+
+## Steps to reproduce
+1. 
+
+## Expected behavior
+
+## Actual behavior
+<!-- If applicable, add screenshots -->
+
+## Versions
+
+<!-- Run `lsb_release -sd` -->
+Operating system:
+
+## Log output
+<!-- (Optional) Copy the logs that are relevant to the bug & paste inside triple backticks below -->
+
+## Additional context
+<!-- (Optional) Add any additional information here -->

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,0 +1,49 @@
+# Copyright 2025 Canonical Ltd.
+# See LICENSE file for licensing details.
+name: Tests
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+on:
+  pull_request:
+
+jobs:
+  lint:
+    name: Lint
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Install tox
+        run: pipx install tox
+      - name: Run linters
+        run: tox run -e lint
+
+  build:
+    name: Build snap
+    uses: canonical/data-platform-workflows/.github/workflows/build_snap.yaml@v32.0.0
+
+  smoke:
+    name: Smoke test snap
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    needs:
+      - lint
+      - build
+    steps:
+      - name: Uninstall MySQL
+        run: sudo apt --purge remove mysql*
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Install tox
+        run: pipx install tox
+      - name: Download snap package(s)
+        uses: actions/download-artifact@v4
+        with:
+          pattern: ${{ needs.build.outputs.artifact-prefix }}-*
+          merge-multiple: true
+      - name: Run tests
+        run: tox run -e smoke

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,32 @@
+# Copyright 2025 Canonical Ltd.
+# See LICENSE file for licensing details.
+name: Release to Snap Store
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+on:
+  push:
+    branches:
+      - 8.0/edge
+    paths:
+      - snap/**
+
+jobs:
+  build:
+    name: Build snap
+    uses: canonical/data-platform-workflows/.github/workflows/build_snap.yaml@v32.0.0
+
+  release:
+    name: Release snap
+    needs:
+      - build
+    uses: canonical/data-platform-workflows/.github/workflows/release_snap.yaml@v32.0.0
+    with:
+      channel: 8.0/edge
+      artifact-prefix: ${{ needs.build.outputs.artifact-prefix }}
+    secrets:
+      snap-store-token: ${{ secrets.SNAP_STORE_TOKEN }}
+    permissions:
+      contents: write  # Needed to create GitHub release

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+*.snap
+*pycache*

--- a/.yamllint
+++ b/.yamllint
@@ -1,0 +1,5 @@
+lint:
+  name: yamllint
+  options:
+    config-data:
+      line-length: disable

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright 2025 Canonical Ltd.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/LICENSE
+++ b/LICENSE
@@ -186,7 +186,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright 2025 Canonical Ltd.
+   Copyright [yyyy] [name of copyright owner]
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/README.md
+++ b/README.md
@@ -1,2 +1,37 @@
-# mysql-snap
-MySQL snap
+# MySQL Snap
+[![Release to Snap Store](https://github.com/canonical/mysql-snap/actions/workflows/release.yaml/badge.svg)](https://github.com/canonical/mysql-snap/actions/workflows/release.yaml)
+
+This repository contains the packaging metadata for creating a snap of PostgreSQL built from the official Ubuntu repositories.
+For more information on snaps, visit [snapcraft.io](https://snapcraft.io/). 
+
+## Installing the Snap
+The snap can be installed directly from the Stap Store. Follow the link below for more information.
+<br>
+
+[![Get it from the Snap Store](https://snapcraft.io/static/images/badges/en/snap-store-black.svg)](https://snapcraft.io/mysql)
+
+## Building the Snap
+### Clone Repository
+```bash
+git clone git@github.com:canonical/mysql-snap.git
+cd mysql-snap
+```
+
+### Installing and Configuring Prerequisites
+```bash
+sudo snap install snapcraft
+sudo snap install lxd
+sudo lxd init --auto
+```
+
+### Packing and Installing the Snap
+```bash
+snapcraft pack
+sudo snap install ./mysql*.snap --devmode
+```
+
+## License
+The MySQL Snap is free software, distributed under the Apache
+Software License, version 2.0. See [LICENSE](https://github.com/canonical/mysql-snap/blob/8.0/edge/LICENSE)
+for more information.
+

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,22 @@
+# Security policy
+
+## What qualifies as a security issue
+
+Credentials leakage, outdated dependencies with known vulnerabilities, and
+other issues that could lead to unprivileged or unauthorized access to the
+database or the system.
+
+## Reporting a vulnerability
+
+The easiest way to report a security issue is through [GitHub](https://github.com/canonical/mysql-snap/security/advisories/new).
+See [Privately reporting a security vulnerability](https://docs.github.com/en/code-securitysecurity-advisories/guidance-on-reporting-and-writing/privately-reporting-a-security-vulnerability)
+for instructions.
+
+The repository admins will be notified of the issue and will work with you
+to determine whether the issue qualifies as a security issue and, if so, in
+which component. We will then handle figuring out a fix, getting a CVE
+assigned and coordinating the release of the fix.
+
+The [Ubuntu Security disclosure and embargo policy](https://ubuntu.com/security/disclosure-policy)
+contains more information about what you can expect when you contact us, and what we
+expect from you.

--- a/snap/hooks/install
+++ b/snap/hooks/install
@@ -26,8 +26,8 @@ $SNAP/usr/sbin/mysqld --initialize --datadir=$SNAP_COMMON/data --user=root
 
 # Throw error if data directory not initialized
 if [ ! -f $SNAP_COMMON/data/mysql.ibd ] ; then
-  echo "Error: MySQL was unable to initialize the data directory at $SNAP_COMMON/data"
-  exit 1
+    echo "Error: MySQL was unable to initialize the data directory at $SNAP_COMMON/data" >&2
+    exit 1
 fi
 
 # Remove "group" and "other" permission access from data directory

--- a/snap/hooks/install
+++ b/snap/hooks/install
@@ -1,34 +1,44 @@
 #!/bin/bash
 
-# Configuration
-mkdir $SNAP_DATA/etc
-cp $SNAP/etc/mysqld.cnf $SNAP_DATA/etc
-chown -R snap_daemon:root $SNAP_DATA/etc
+init_snap_data() {
+    # Configuration
+    mkdir $SNAP_DATA/etc
+    cp $SNAP/etc/mysqld.cnf $SNAP_DATA/etc
+    chown -R snap_daemon:root $SNAP_DATA/etc
 
-# Logs
-mkdir $SNAP_DATA/log
-touch $SNAP_DATA/log/error.log
-touch $SNAP_DATA/log/query.log
-touch $SNAP_DATA/log/mysql-bin.log
-touch $SNAP_DATA/log/mysql-slow.log
-chown -R snap_daemon:root $SNAP_DATA/log
+    # Logs
+    mkdir $SNAP_DATA/log
+    touch $SNAP_DATA/log/error.log
+    touch $SNAP_DATA/log/query.log
+    touch $SNAP_DATA/log/mysql-bin.log
+    touch $SNAP_DATA/log/mysql-slow.log
+    chown -R snap_daemon:root $SNAP_DATA/log
 
-# Sockets
-mkdir $SNAP_DATA/run
-chown -R snap_daemon:root $SNAP_DATA/run
+    # Sockets
+    mkdir $SNAP_DATA/run
+    chown -R snap_daemon:root $SNAP_DATA/run
+}
 
-# Create directory for storing data and set permissions
-mkdir $SNAP_COMMON/data
-chown snap_daemon:root $SNAP_COMMON/data
+init_snap_common() {
+    # Create directory for storing data and set permissions
+    mkdir $SNAP_COMMON/data
+    chown snap_daemon:root $SNAP_COMMON/data
 
-# Initialize data directory
-$SNAP/usr/sbin/mysqld --initialize --datadir=$SNAP_COMMON/data --user=root
+    # Initialize data directory
+    $SNAP/usr/sbin/mysqld \
+        --defaults-file=$SNAP/etc/my.cnf \
+        --user=root \
+        --initialize
 
-# Throw error if data directory not initialized
-if [ ! -f $SNAP_COMMON/data/mysql.ibd ] ; then
-    echo "Error: MySQL was unable to initialize the data directory at $SNAP_COMMON/data" >&2
-    exit 1
-fi
+    # Throw error if data directory not initialized
+    if [ ! -f $SNAP_COMMON/data/mysql.ibd ] ; then
+        echo "Error: MySQL was unable to initialize the data directory at $SNAP_COMMON/data" >&2
+        exit 1
+    fi
 
-# Remove "group" and "other" permission access from data directory
-chmod go-rwx $SNAP_COMMON/data
+    # Remove "group" and "other" permission access from data directory
+    chmod go-rwx $SNAP_COMMON/data
+}
+
+init_snap_data
+init_snap_common

--- a/snap/hooks/install
+++ b/snap/hooks/install
@@ -40,5 +40,23 @@ init_snap_common() {
     chmod go-rwx $SNAP_COMMON/data
 }
 
+enable_auth_socket() {
+    local init_file="$(mktemp)"
+
+    echo "INSTALL PLUGIN auth_socket SONAME 'auth_socket.so';" >> "$init_file"
+    echo "ALTER USER 'root'@'localhost' IDENTIFIED WITH 'auth_socket';" >> "$init_file"
+    echo "SHUTDOWN;" >> "$init_file"
+    chown snap_daemon:root "$init_file"
+
+    # Run init file
+    $SNAP/usr/sbin/mysqld \
+        --defaults-file=$SNAP/etc/my.cnf \
+        --user=snap_daemon \
+        --skip-networking \
+        --skip-mysqlx \
+        --init-file="$init_file"
+}
+
 init_snap_data
 init_snap_common
+enable_auth_socket

--- a/snap/hooks/install
+++ b/snap/hooks/install
@@ -1,0 +1,34 @@
+#!/bin/bash
+
+# Configuration
+mkdir $SNAP_DATA/etc
+cp $SNAP/etc/mysqld.cnf $SNAP_DATA/etc
+chown -R snap_daemon:root $SNAP_DATA/etc
+
+# Logs
+mkdir $SNAP_DATA/log
+touch $SNAP_DATA/log/error.log
+touch $SNAP_DATA/log/query.log
+touch $SNAP_DATA/log/mysql-bin.log
+touch $SNAP_DATA/log/mysql-slow.log
+chown -R snap_daemon:root $SNAP_DATA/log
+
+# Sockets
+mkdir $SNAP_DATA/run
+chown -R snap_daemon:root $SNAP_DATA/run
+
+# Create directory for storing data and set permissions
+mkdir $SNAP_COMMON/data
+chown snap_daemon:root $SNAP_COMMON/data
+
+# Initialize data directory
+$SNAP/usr/sbin/mysqld --initialize --datadir=$SNAP_COMMON/data --user=root
+
+# Throw error if data directory not initialized
+if [ ! -f $SNAP_COMMON/data/mysql.ibd ] ; then
+  echo "Error: MySQL was unable to initialize the data directory at $SNAP_COMMON/data"
+  exit 1
+fi
+
+# Remove "group" and "other" permission access from data directory
+chmod go-rwx $SNAP_COMMON/data

--- a/snap/local/bin/mysqld.sh
+++ b/snap/local/bin/mysqld.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+exec "${SNAP}/usr/bin/setpriv" \
+    --clear-groups \
+    --reuid snap_daemon \
+    --regid root \
+    -- \
+    "${SNAP}/usr/sbin/mysqld" --defaults-file="${SNAP}/etc/my.cnf"

--- a/snap/local/bin/setpriv.sh
+++ b/snap/local/bin/setpriv.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+exec "${SNAP}/usr/bin/setpriv" \
+    --clear-groups \
+    --reuid snap_daemon \
+    --regid root \
+    -- \
+    "${@}"

--- a/snap/local/etc/my.cnf
+++ b/snap/local/etc/my.cnf
@@ -1,0 +1,8 @@
+# Default server settings
+[mysqld]
+user                = snap_daemon
+bind-address        = 127.0.0.1
+mysqlx-bind-address = 127.0.0.1
+
+# Import all .cnf files from configuration directory
+!includedir /var/snap/mysql/current/etc

--- a/snap/local/etc/my.cnf
+++ b/snap/local/etc/my.cnf
@@ -1,12 +1,12 @@
 # Default server settings
 [mysqld]
-pid-file            = /var/snap/mysql/current/run/mysqld.pid
-socket              = /var/snap/mysql/current/run/mysqld.sock
-datadir             = /var/snap/mysql/common/data
+pid-file            = /var/snap/_NAME_/current/run/mysqld.pid
+socket              = /var/snap/_NAME_/current/run/mysqld.sock
+datadir             = /var/snap/_NAME_/common/data
 user                = snap_daemon
 bind-address        = 127.0.0.1
 mysqlx-bind-address = 127.0.0.1
 secure-file-priv    = NULL
 
 # Import all .cnf files from configuration directory
-!includedir /var/snap/mysql/current/etc
+!includedir /var/snap/_NAME_/current/etc

--- a/snap/local/etc/my.cnf
+++ b/snap/local/etc/my.cnf
@@ -1,8 +1,12 @@
 # Default server settings
 [mysqld]
+pid-file            = /var/snap/mysql/current/run/mysqld.pid
+socket              = /var/snap/mysql/current/run/mysqld.sock
+datadir             = /var/snap/mysql/common/data
 user                = snap_daemon
 bind-address        = 127.0.0.1
 mysqlx-bind-address = 127.0.0.1
+secure-file-priv    = NULL
 
 # Import all .cnf files from configuration directory
 !includedir /var/snap/mysql/current/etc

--- a/snap/local/etc/mysqld.cnf
+++ b/snap/local/etc/mysqld.cnf
@@ -9,8 +9,12 @@
 # * General Settings
 #
 [mysqld]
+pid-file            = /var/snap/mysql/current/run/mysqld.pid
+socket              = /var/snap/mysql/current/run/mysqld.sock
+datadir             = /var/snap/mysql/common/data
 bind-address		= 127.0.0.1
 mysqlx-bind-address	= 127.0.0.1
+secure-file-priv    = NULL
 port                = 3306
 mysqlx_port		    = 33060
 

--- a/snap/local/etc/mysqld.cnf
+++ b/snap/local/etc/mysqld.cnf
@@ -1,0 +1,51 @@
+#
+# MySQL Server Configuration
+#
+# For a full list of available options and explanations, see:
+# https://dev.mysql.com/doc/refman/en/server-system-variables.html
+#
+
+#
+# * General Settings
+#
+[mysqld]
+bind-address		= 127.0.0.1
+mysqlx-bind-address	= 127.0.0.1
+port                = 3306
+mysqlx_port		    = 33060
+
+#
+# * Fine Tuning
+#
+key_buffer_size		   = 16M
+myisam-recover-options = BACKUP
+# max_allowed_packet   = 64M
+# thread_stack         = 256K
+# thread_cache_size    = -1
+# max_connections      = 151
+# table_open_cache     = 4000
+
+#
+# * Logging and Replication
+#
+# Log all queries
+# Be aware that this log type is a performance killer.
+# general_log_file = /var/snap/mysql/current/log/query.log
+# general_log      = 1
+
+# Error log - should be very few entries.
+log_error = /var/snap/mysql/current/log/error.log
+
+# Here you can see queries with especially long duration
+# slow_query_log      = 1
+# slow_query_log_file = /var/snap/mysql/current/log/mysql-slow.log
+# long_query_time     = 2
+# log-queries-not-using-indexes
+
+# The following can be used as easy to replay backup logs or for replication.
+# server-id                  = 1
+# log_bin                    = /var/snap/mysql/current/log/mysql-bin.log
+# binlog_expire_logs_seconds = 2592000
+max_binlog_size              = 100M
+# binlog_do_db               = include_database_name
+# binlog_ignore_db           = include_database_name

--- a/snap/local/etc/mysqld.cnf
+++ b/snap/local/etc/mysqld.cnf
@@ -9,9 +9,9 @@
 # * General Settings
 #
 [mysqld]
-pid-file            = /var/snap/mysql/current/run/mysqld.pid
-socket              = /var/snap/mysql/current/run/mysqld.sock
-datadir             = /var/snap/mysql/common/data
+pid-file            = /var/snap/_NAME_/current/run/mysqld.pid
+socket              = /var/snap/_NAME_/current/run/mysqld.sock
+datadir             = /var/snap/_NAME_/common/data
 bind-address		= 127.0.0.1
 mysqlx-bind-address	= 127.0.0.1
 secure-file-priv    = NULL
@@ -34,21 +34,21 @@ myisam-recover-options = BACKUP
 #
 # Log all queries
 # Be aware that this log type is a performance killer.
-# general_log_file = /var/snap/mysql/current/log/query.log
+# general_log_file = /var/snap/_NAME_/current/log/query.log
 # general_log      = 1
 
 # Error log - should be very few entries.
-log_error = /var/snap/mysql/current/log/error.log
+log_error = /var/snap/_NAME_/current/log/error.log
 
 # Here you can see queries with especially long duration
 # slow_query_log      = 1
-# slow_query_log_file = /var/snap/mysql/current/log/mysql-slow.log
+# slow_query_log_file = /var/snap/_NAME_/current/log/mysql-slow.log
 # long_query_time     = 2
 # log-queries-not-using-indexes
 
 # The following can be used as easy to replay backup logs or for replication.
 # server-id                  = 1
-# log_bin                    = /var/snap/mysql/current/log/mysql-bin.log
+# log_bin                    = /var/snap/_NAME_/current/log/mysql-bin.log
 # binlog_expire_logs_seconds = 2592000
 max_binlog_size              = 100M
 # binlog_do_db               = include_database_name

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -88,3 +88,7 @@ parts:
     plugin: dump
     source: snap/local
     source-type: local
+    override-prime: |
+      craftctl default
+      sed -i 's/_NAME_/$SNAPCRAFT_PROJECT_NAME/g' bin/*.sh
+      sed -i 's/_NAME_/$SNAPCRAFT_PROJECT_NAME/g' etc/*.cnf

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -29,7 +29,7 @@ slots:
     interface: content
     content: socket-directory
     write:
-      - $SNAP_COMMON/run
+      - $SNAP_DATA/run
 
 apps:
   mysqld:

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,0 +1,90 @@
+name: mysql
+base: core24
+version: '8.0.42'
+summary: MySQL server in a snap.
+description: |
+  The MySQL software delivers a very fast, multithreaded, multi-user,
+  and robust SQL (Structured Query Language) database server. MySQL
+  Server is intended for mission-critical, heavy-load production
+  systems as well as for embedding into mass-deployed software.
+
+grade: stable
+confinement: strict
+license: Apache-2.0
+platforms:
+  amd64:
+  arm64:
+
+system-usernames:
+  snap_daemon: shared
+
+hooks:
+  install:
+    plugs:
+      - network
+      - network-bind
+
+slots:
+  mysql-sockets:
+    interface: content
+    content: socket-directory
+    write:
+      - $SNAP_COMMON/run
+
+apps:
+  mysqld:
+    command: bin/mysqld.sh
+    daemon: simple
+    plugs:
+      - network
+      - network-bind
+  mysql:
+    command: usr/bin/mysql
+    plugs:
+      - network
+  mysqladmin:
+    command: usr/bin/mysqladmin
+    plugs:
+      - network
+  mysqlcheck:
+    command: usr/bin/mysqlcheck
+    plugs:
+      - network
+  mysqldump:
+    command: usr/bin/mysqldump
+    plugs:
+      - network
+  mysqlimport:
+    command: usr/bin/mysqlimport
+    plugs:
+      - network
+  mysqlshow:
+    command: usr/bin/mysqlshow
+    plugs:
+      - network
+  mysqlslap:
+    command: usr/bin/mysqlslap
+    plugs:
+      - network
+
+parts:
+  packages-deb:
+    plugin: nil
+    stage-packages:
+      - mysql-server-8.0=8.0.42-0ubuntu0.24.04.1
+      - util-linux
+    organize:
+      usr/share/doc/mysql-server-8.0/copyright: licenses/COPYRIGHT-mysql-server-8.0
+      usr/share/doc/util-linux/copyright: licenses/COPYRIGHT-util-linux
+  snap-license:
+    plugin: dump
+    source: .
+    source-type: local
+    stage:
+      - licenses/LICENSE-snap
+    organize:
+      LICENSE: licenses/LICENSE-snap
+  snap-scripts:
+    plugin: dump
+    source: snap/local
+    source-type: local

--- a/tests/test_smoke.py
+++ b/tests/test_smoke.py
@@ -1,0 +1,81 @@
+# Copyright 2025 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+import subprocess
+import time
+
+import pytest
+import yaml
+
+
+def test_install():
+    with open("snap/snapcraft.yaml") as file:
+        snapcraft = yaml.safe_load(file)
+
+    snap_name = snapcraft['name']
+    snap_version = snapcraft['version']
+
+    subprocess.run(
+        f"sudo snap remove --purge {snap_name}".split(),
+        check=True,
+    )
+    subprocess.run(
+        f"sudo snap install ./{snap_name}_{snap_version}_amd64.snap --devmode".split(),
+        check=True,
+    )
+
+
+@pytest.mark.run(after="test_install")
+def test_all_apps():
+    with open("snap/snapcraft.yaml") as file:
+        snapcraft = yaml.safe_load(file)
+
+    override = {"mysqladmin": "--print-defaults"}
+    skip = []
+
+    snap_apps = snapcraft["apps"]
+    snap_name = snapcraft['name']
+
+    for app, data in snap_apps.items():
+        if bool(data.get("daemon")) or app in skip:
+            continue
+
+        if app == snap_name:
+            command = f"{snap_name}"
+        else:
+            command = f"{snap_name}.{app}"
+
+        print(f"Running {command}...")
+        subprocess.check_output(
+            f"sudo {command} {override.get(app, '--help')}".split()
+        )
+
+
+@pytest.mark.run(after="test_install")
+def test_all_services():
+    with open("snap/snapcraft.yaml") as file:
+        snapcraft = yaml.safe_load(file)
+
+    skip = []
+
+    snap_apps = snapcraft["apps"]
+    snap_name = snapcraft['name']
+
+    for app, data in snap_apps.items():
+        if not bool(data.get("daemon")) or app in skip:
+            continue
+
+        print(f"Running {snap_name}.{app}...")
+        subprocess.check_output(
+            f"sudo snap start {snap_name}.{app}".split()
+        )
+
+        time.sleep(5)
+        service = subprocess.check_output(
+            f"snap services {snap_name}.{app}".split()
+        )
+        subprocess.check_output(
+            f"sudo snap stop {snap_name}.{app}".split()
+        )
+
+        assert "active" in service.decode()

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,18 @@
+[tox]
+no_package = True
+env_list = lint,smoke
+
+[testenv:lint]
+description = Check code against coding style standards
+deps =
+    yamllint
+commands =
+    yamllint --no-warnings ./snap/
+
+[testenv:smoke]
+description = Smoke test for snap
+deps =
+    pytest
+    pyyaml
+commands =
+    pytest -vv --no-header --tb native --log-cli-level=INFO tests/test_smoke.py -s


### PR DESCRIPTION
This PR creates the initial version of the MySQL slim snap (only containing `mysql-server` binary).

### Implementation
The definition of the `snapcraft.yaml` file as well as the shell script and config files has been copied from the [repository](https://github.com/DownThePark/mysql-snap) currently releasing the MySQL slim snap. With the following changes:

- Instead of building the MySQL binaries from source, we are installing them from the `.deb` package.
- Instead of creating a custom `install.sh` script, we are relying on the default execution of the `install` hook.
- Instead of creating the data directory with `--initialize-insecure`, we are using `--initialize`, similar to the charmed snap ([reference](https://github.com/canonical/charmed-mysql-snap/blob/32d2923e3e2c0333bf392fc468b448cf7d58a23c/snap/hooks/install#L50)).
- In addition to the stated apps, we are including all other non-deprecated binaries (according to the [official docs](https://dev.mysql.com/doc/refman/8.0/en/programs-client.html)):
  - [mysqlcheck](https://dev.mysql.com/doc/refman/8.0/en/mysqlcheck.html).
  - [mysqlshow](https://dev.mysql.com/doc/refman/8.0/en/mysqlshow.html).
  - [mysqlslap](https://dev.mysql.com/doc/refman/8.0/en/mysqlslap.html).

### Pending questions
- ~I have not included the auth socket plugin ([reference](https://github.com/DownThePark/mysql-snap/blob/7cbadcc8c38bdcc9a9e7417bb057eee378dc9dc5/snap/local/snap/command-chain/install.sh#L43-L51)). **Should we add it?**~
- ~I included the `setpriv.sh` script even if it is not used anywhere. **Should we prune it?**~

### Pending work
- Add `SNAP_STORE_TOKEN` to the GitHub Actions secrets (cc @paulomach)