### PR TITLE
[MISC] Fix permission problems

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,9 +25,12 @@ sudo lxd init --auto
 ```
 
 ### Packing and Installing the Snap
+In order to properly test the confinement of the snap, we must install it using the `--dangerous` flag,
+instead of the `--devmode` one. See snap [installation modes](https://snapcraft.io/docs/install-modes).
+
 ```bash
 snapcraft pack
-sudo snap install ./mysql*.snap --devmode
+sudo snap install ./mysql*.snap --dangerous
 ```
 
 ## License

--- a/snap/hooks/install
+++ b/snap/hooks/install
@@ -25,7 +25,7 @@ init_snap_common() {
     chown snap_daemon:root $SNAP_COMMON/data
 
     # Initialize data directory
-    $SNAP/usr/sbin/mysqld \
+    $SNAP/bin/setpriv.sh $SNAP/usr/sbin/mysqld \
         --defaults-file=$SNAP/etc/my.cnf \
         --user=root \
         --initialize
@@ -49,7 +49,7 @@ enable_auth_socket() {
     chown snap_daemon:root "$init_file"
 
     # Run init file
-    $SNAP/usr/sbin/mysqld \
+    $SNAP/bin/setpriv.sh $SNAP/usr/sbin/mysqld \
         --defaults-file=$SNAP/etc/my.cnf \
         --user=snap_daemon \
         --skip-networking \

--- a/snap/local/etc/my.cnf
+++ b/snap/local/etc/my.cnf
@@ -3,10 +3,11 @@
 pid-file            = /var/snap/_NAME_/current/run/mysqld.pid
 socket              = /var/snap/_NAME_/current/run/mysqld.sock
 datadir             = /var/snap/_NAME_/common/data
+secure-file-priv    = NULL
 user                = snap_daemon
 bind-address        = 127.0.0.1
 mysqlx-bind-address = 127.0.0.1
-secure-file-priv    = NULL
+mysqlx-socket		= /var/snap/_NAME_/current/run/mysqlx.sock
 
 # Import all .cnf files from configuration directory
 !includedir /var/snap/_NAME_/current/etc

--- a/snap/local/etc/mysqld.cnf
+++ b/snap/local/etc/mysqld.cnf
@@ -12,11 +12,12 @@
 pid-file            = /var/snap/_NAME_/current/run/mysqld.pid
 socket              = /var/snap/_NAME_/current/run/mysqld.sock
 datadir             = /var/snap/_NAME_/common/data
-bind-address		= 127.0.0.1
-mysqlx-bind-address	= 127.0.0.1
 secure-file-priv    = NULL
+bind-address		= 127.0.0.1
 port                = 3306
-mysqlx_port		    = 33060
+mysqlx-bind-address	= 127.0.0.1
+mysqlx-port		    = 33060
+mysqlx-socket		= /var/snap/_NAME_/current/run/mysqlx.sock
 
 #
 # * Fine Tuning

--- a/tests/test_smoke.py
+++ b/tests/test_smoke.py
@@ -20,7 +20,7 @@ def test_install():
         check=True,
     )
     subprocess.run(
-        f"sudo snap install ./{snap_name}_{snap_version}_amd64.snap --devmode".split(),
+        f"sudo snap install ./{snap_name}_{snap_version}_amd64.snap --dangerous".split(),
         check=True,
     )
 


### PR DESCRIPTION
This PR improves the strictness of the testing installation, in order to verify that the snap can be installed with the permissions setup in the `install` hook. This is not always the case, so we must verify using the `--dangerous` installation flag, instead of the `--devmode` one.

### Additional changes
- Run initialization binaries using the `setpriv.sh` script (same as the non-canonical [install script](https://github.com/DownThePark/mysql-snap/blob/7cbadcc8c38bdcc9a9e7417bb057eee378dc9dc5/snap/local/snap/command-chain/install.sh)).
- Add MySQL X socket configuration.

---

Suggested by @taurus-forever.