### PR TITLE
Specify mysqld.sock file in commands

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -40,31 +40,31 @@ apps:
       - network
       - network-bind
   mysql:
-    command: usr/bin/mysql
+    command: usr/bin/mysql -S $SNAP_DATA/run/mysqld.sock
     plugs:
       - network
   mysqladmin:
-    command: usr/bin/mysqladmin
+    command: usr/bin/mysqladmin -S $SNAP_DATA/run/mysqld.sock
     plugs:
       - network
   mysqlcheck:
-    command: usr/bin/mysqlcheck
+    command: usr/bin/mysqlcheck -S $SNAP_DATA/run/mysqld.sock
     plugs:
       - network
   mysqldump:
-    command: usr/bin/mysqldump
+    command: usr/bin/mysqldump -S $SNAP_DATA/run/mysqld.sock
     plugs:
       - network
   mysqlimport:
-    command: usr/bin/mysqlimport
+    command: usr/bin/mysqlimport -S $SNAP_DATA/run/mysqld.sock
     plugs:
       - network
   mysqlshow:
-    command: usr/bin/mysqlshow
+    command: usr/bin/mysqlshow -S $SNAP_DATA/run/mysqld.sock
     plugs:
       - network
   mysqlslap:
-    command: usr/bin/mysqlslap
+    command: usr/bin/mysqlslap -S $SNAP_DATA/run/mysqld.sock
     plugs:
       - network
 

--- a/tests/test_smoke.py
+++ b/tests/test_smoke.py
@@ -30,7 +30,7 @@ def test_all_apps():
     with open("snap/snapcraft.yaml") as file:
         snapcraft = yaml.safe_load(file)
 
-    override = {"mysqladmin": "--print-defaults"}
+    override = {}
     skip = []
 
     snap_apps = snapcraft["apps"]
@@ -47,7 +47,7 @@ def test_all_apps():
 
         print(f"Running {command}...")
         subprocess.check_output(
-            f"sudo {command} {override.get(app, '--help')}".split()
+            f"sudo {command} {override.get(app, '--version')}".split()
         )
 
 


### PR DESCRIPTION
By appending `-S $SNAP_DATA/run/mysqld.sock` to each command by default, this would save the end user from having to manually specify the socket file each time a command is run.

If the user would like to connect to another MySQL instance, they can just use the `-S <socket>` flag like normal, and their flag would take precedence.