### PR TITLE
[DPE-8301] Update mysql to 8.0.43

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,6 +1,6 @@
 name: mysql
 base: core24
-version: '8.0.42'
+version: '8.0.43'
 summary: MySQL server in a snap.
 description: |
   The MySQL software delivers a very fast, multithreaded, multi-user,
@@ -72,7 +72,7 @@ parts:
   packages-deb:
     plugin: nil
     stage-packages:
-      - mysql-server-8.0=8.0.42-0ubuntu0.24.04.2
+      - mysql-server-8.0=8.0.43-0ubuntu0.24.04.1
       - util-linux
     organize:
       usr/share/doc/mysql-server-8.0/copyright: licenses/COPYRIGHT-mysql-server-8.0


### PR DESCRIPTION
This PR updates mysql snap to version 8.0.43.
