### PR TITLE
[misc] Expose mysqlbinlog

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![Release to Snap Store](https://github.com/canonical/mysql-snap/actions/workflows/release.yaml/badge.svg)](https://github.com/canonical/mysql-snap/actions/workflows/release.yaml)
 
-This repository contains the packaging metadata for creating a snap of PostgreSQL built from the official Ubuntu repositories.
+This repository contains the packaging metadata for creating a snap of MySQL built from the official Ubuntu repositories.
 For more information on snaps, visit [snapcraft.io](https://snapcraft.io/).
 
 ## Installing the Snap

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -67,6 +67,8 @@ apps:
     command: usr/bin/mysqlslap -S $SNAP_DATA/run/mysqld.sock
     plugs:
       - network
+  mysqlbinlog:
+    command: usr/bin/mysqlbinlog
 
 parts:
   packages-deb:


### PR DESCRIPTION
As an support session recently demonstrated, using mysqlbinlog to inspect binlog files can be crucial to fix cluster issues.
(Plus an typo opsie on the README.md)

p.s.: `charmed-mysql-snap` already expose it
