### PR TITLE
[MISC] Fix release workflow

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -18,6 +18,8 @@ jobs:
   build:
     name: Build snap
     uses: canonical/data-platform-workflows/.github/workflows/build_snap.yaml@v40.0.2
+    with:
+      snapcraft-snap-channel: latest/edge
 
   release:
     name: Release snap


### PR DESCRIPTION
This PR fixes the snap building process when releasing to the snap-store. When building using the `core26` base, it is mandatory to be pointing snapcraft at `latest/edge` channel.

---

Fixes PR https://github.com/canonical/mysql-snap/pull/10