### PR TITLE
[MISC] 8.0 - Use mysql-safe as a supervisor process

### DIFF
--- a/snap/local/bin/mysqld.sh
+++ b/snap/local/bin/mysqld.sh
@@ -5,4 +5,4 @@ exec "${SNAP}/usr/bin/setpriv" \
     --reuid snap_daemon \
     --regid root \
     -- \
-    "${SNAP}/usr/sbin/mysqld" --defaults-file="${SNAP}/etc/my.cnf"
+    "${SNAP}/usr/bin/mysqld_safe" --defaults-file="${SNAP}/etc/my.cnf"


### PR DESCRIPTION
This PR replaces the vanilla `mysqld` binary by the provided `mysqld_safe` one, in order to have a _supervisor process_ able to capture the restart exit code, needed for the correct behavior of MySQL when preparing for / joining a cluster. As an alternative, we could create our own shell-script to capture exit code `16`.

---

Reference: https://dev.mysql.com/doc/refman/8.0/en/restart.html