### PR TITLE
[MISC] 8.0 - Custom supervisor script

### DIFF
--- a/snap/local/bin/mysqld.sh
+++ b/snap/local/bin/mysqld.sh
@@ -1,8 +1,28 @@
 #!/bin/bash
 
-exec "${SNAP}/usr/bin/setpriv" \
-    --clear-groups \
-    --reuid snap_daemon \
-    --regid root \
-    -- \
-    "${SNAP}/usr/bin/mysqld_safe" --defaults-file="${SNAP}/etc/my.cnf"
+# This script is designed to be a "supervisor process" for MySQL Server.
+# Such process is needed for it to be able to restart upon config changes.
+# Ref: https://dev.mysql.com/doc/refman/8.0/en/restart.html
+
+export MYSQLD_PARENT_PID=$$
+export MYSQLD_RESTART_CODE=16
+
+while true; do
+    # For security measures, applications should not be run as sudo.
+    # Execute mysqld as the non-sudo user: snap-daemon
+    exec "${SNAP}/usr/bin/setpriv" \
+        --clear-groups \
+        --reuid snap_daemon \
+        --regid root \
+        -- \
+        "${SNAP}/usr/sbin/mysqld" --defaults-file="${SNAP}/etc/my.cnf" &
+
+    wait $!
+
+    EXIT_CODE=$?
+
+    if [ ${EXIT_CODE} -ne ${MYSQLD_RESTART_CODE} ]; then
+        echo "MySQL exited with code ${EXIT_CODE}."
+        break
+    fi
+done


### PR DESCRIPTION
This PR defines a custom supervisor script to manage the `mysqld` process, moving away from `mysqld_safe`.

Previous attempts to move away from the deprecated `mysqld_safe` script were unsuccessful, because following the MySQL Restart page [guide](https://dev.mysql.com/doc/refman/8.0/en/restart.html) about how to define a custom supervisor process does not account for such supervisor process to be run, yet again, by another supervisor process (in our case, SystemD). For that to work, we need to run the binary as a background process within the script.

Running this script as a Snap service (i.e. SystemD service), does not require to trap signals, as SystemD is smart enough to track all PIDs started under a given service (see [KillMode](https://manpages.ubuntu.com/manpages/focal/man5/systemd.kill.5.html) default value).