### PR TITLE
Update readme to replace Postresql with MySQL

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![Release to Snap Store](https://github.com/canonical/mysql-snap/actions/workflows/release.yaml/badge.svg)](https://github.com/canonical/mysql-snap/actions/workflows/release.yaml)
 
-This repository contains the packaging metadata for creating a snap of PostgreSQL built from the official Ubuntu repositories.
+This repository contains the packaging metadata for creating a snap of MySQL built from the official Ubuntu repositories.
 For more information on snaps, visit [snapcraft.io](https://snapcraft.io/).
 
 ## Installing the Snap


### PR DESCRIPTION
Realized that the name update fell through the gaps -- and it appears as summary in the Google search index results.