### PR TITLE
[MISC] 8.0 - Fix release workflow permissions

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -30,4 +30,5 @@ jobs:
     secrets:
       snap-store-token: ${{ secrets.SNAP_STORE_TOKEN }}
     permissions:
+      actions: read    # Needed for GitHub API call to get workflow version
       contents: write  # Needed to create git tags


### PR DESCRIPTION
This PR is a follow-up to https://github.com/canonical/mysql-snap/pull/20, where the release workflow permissions were not properly updated.

See [CI run](https://github.com/canonical/mysql-snap/actions/runs/24338590035).