### PR TITLE
[MISC] 8.4 - Remove core26 left-overs

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -20,7 +20,7 @@ jobs:
     name: Build snap
     uses: canonical/data-platform-workflows/.github/workflows/build_snap.yaml@v49.0.1
     with:
-      snapcraft-snap-channel: latest/edge
+      snapcraft-snap-channel: latest/candidate
     permissions:
       actions: read
       contents: read
@@ -53,7 +53,7 @@ jobs:
           merge-multiple: true
       - name: Install dependencies
         run: |
-          sudo snap install snapcraft --classic
+          sudo snap install snapcraft --candidate --classic
           # lxd is necessary for spread
           sudo snap install lxd
           sudo adduser "$USER" lxd

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -19,7 +19,7 @@ jobs:
     name: Build snap
     uses: canonical/data-platform-workflows/.github/workflows/build_snap.yaml@v49.0.1
     with:
-      snapcraft-snap-channel: latest/edge
+      snapcraft-snap-channel: latest/candidate
     permissions:
       actions: read
       contents: read

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,6 +1,5 @@
 name: mysql
 base: core26
-build-base: devel
 version: '8.4.8'
 summary: MySQL server in a snap.
 description: |
@@ -9,10 +8,7 @@ description: |
   Server is intended for mission-critical, heavy-load production
   systems as well as for embedding into mass-deployed software.
 
-assumes:
-  - snapd2.73
-
-grade: devel
+grade: stable
 confinement: strict
 license: Apache-2.0
 platforms:

--- a/spread.yaml
+++ b/spread.yaml
@@ -11,9 +11,6 @@ suites:
     summary: General integration tests
     prepare: |
       apt --purge remove mysql*
-      snap install snapd --edge  # TODO: remove once snapd 2.74 is out
-      snap refresh snapd --edge  # TODO: remove once snapd 2.74 is out
-      snap install core26 --edge # TODO: remove once core26 latest/stable is out
     prepare-each: |
       snap install "$CRAFT_ARTIFACT" --dangerous --jailmode
       until [ -S /var/snap/mysql/current/run/mysqld.sock ]; do


### PR DESCRIPTION
This PR removes all the `core26` installation leftovers when such base did not had a stable release.