### PR TITLE
[DPE-9970] 8.4 - Remove 26.04 candidate install

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -19,8 +19,6 @@ jobs:
   build:
     name: Build snap
     uses: canonical/data-platform-workflows/.github/workflows/build_snap.yaml@v49
-    with:
-      snapcraft-snap-channel: latest/candidate
     permissions:
       actions: read
       contents: read
@@ -53,7 +51,7 @@ jobs:
           merge-multiple: true
       - name: Install dependencies
         run: |
-          sudo snap install snapcraft --candidate --classic
+          sudo snap install snapcraft --classic
           # lxd is necessary for spread
           sudo snap install lxd
           sudo adduser "$USER" lxd

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -18,8 +18,6 @@ jobs:
   build:
     name: Build snap
     uses: canonical/data-platform-workflows/.github/workflows/build_snap.yaml@v49
-    with:
-      snapcraft-snap-channel: latest/candidate
     permissions:
       actions: read
       contents: read

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,6 +1,6 @@
 name: mysql
 base: core26
-version: '8.4.8'
+version: '8.4.9'
 summary: MySQL server in a snap.
 description: |
   The MySQL software delivers a very fast, multithreaded, multi-user,
@@ -72,7 +72,7 @@ parts:
   packages-deb:
     plugin: nil
     stage-packages:
-      - mysql-server
+      - mysql-server=8.4.9-0ubuntu0.26.04.1
       - util-linux
     organize:
       usr/share/doc/mysql-server-8.4/copyright: licenses/COPYRIGHT-mysql-server-8.4


### PR DESCRIPTION
This PR removes the installation of `snapcraft` from candidate, now that version 9.0.0 got promoted to stable.

### Additional changes:
- MySQL Server bumped to `8.4.9`.