### PR TITLE
[MISC] 8.0 - Bump MySQL to version 8.0.46

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -12,17 +12,22 @@ on:
 jobs:
   lint:
     name: Lint
-    uses: canonical/data-platform-workflows/.github/workflows/lint_workflows.yaml@v46.0.0
+    uses: canonical/data-platform-workflows/.github/workflows/lint_workflows.yaml@v49
+    permissions:
+      contents: read
 
   build:
     name: Build snap
-    uses: canonical/data-platform-workflows/.github/workflows/build_snap.yaml@v46.0.0
+    uses: canonical/data-platform-workflows/.github/workflows/build_snap.yaml@v49
+    permissions:
+      actions: read
+      contents: read
 
   test:
     name: Test snap | ${{ matrix.base.version }} ${{ matrix.platform.arch }}
     timeout-minutes: 10
-    # runs-on: [self-hosted, linux, "${{ matrix.platform.host_arch }}", "${{ matrix.base.codename }}", large]
     runs-on: "ubuntu-${{ matrix.base.version }}${{ matrix.platform.gh_suffix }}"
+    permissions: {}
     strategy:
       fail-fast: false
       matrix:
@@ -36,9 +41,11 @@ jobs:
       - build
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
+        with:
+          persist-credentials: false
       - name: Download snap package(s)
-        uses: actions/download-artifact@v5
+        uses: actions/download-artifact@v8
         with:
           pattern: ${{ needs.build.outputs.artifact-prefix }}-*-${{ matrix.platform.arch }}
           merge-multiple: true

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -17,13 +17,16 @@ on:
 jobs:
   build:
     name: Build snap
-    uses: canonical/data-platform-workflows/.github/workflows/build_snap.yaml@v46.0.0
+    uses: canonical/data-platform-workflows/.github/workflows/build_snap.yaml@v49
+    permissions:
+      actions: read
+      contents: read
 
   release:
     name: Release snap
     needs:
       - build
-    uses: canonical/data-platform-workflows/.github/workflows/release_snap_edge.yaml@v46.0.0
+    uses: canonical/data-platform-workflows/.github/workflows/release_snap_edge.yaml@v49
     with:
       track: 8.0
       artifact-prefix: ${{ needs.build.outputs.artifact-prefix }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -28,7 +28,7 @@ jobs:
       - build
     uses: canonical/data-platform-workflows/.github/workflows/release_snap_edge.yaml@v49
     with:
-      track: 8.0
+      track: '8.0'
       artifact-prefix: ${{ needs.build.outputs.artifact-prefix }}
     secrets:
       snap-store-token: ${{ secrets.SNAP_STORE_TOKEN }}

--- a/.github/zizmor.yaml
+++ b/.github/zizmor.yaml
@@ -1,0 +1,27 @@
+rules:
+  # Allowlist trusted actions
+  forbidden-uses:
+    config:
+      # Actions in this list have remote code execution in our workflows. Even if the workflow has
+      # limited permissions, those can be escaped. See https://github.com/AdnaneKhan/Cacheract and
+      # "But Wait, There’s More" section of
+      # https://www.praetorian.com/blog/codeqleaked-public-secrets-exposure-leads-to-supply-chain-attack-on-github-codeql/
+      # In general, this list should be limited to organizations that we trust to have a baseline
+      # level of operational security. Avoid adding actions that could be replaced with a few lines
+      # of bash.
+      allow:  # Get approval from your manager before adding actions to this list.
+        - canonical/*
+        - actions/*
+  # Pinning actions to a commit SHA has a security tradeoff—pinned actions cannot be later
+  # compromised, but they also cannot be security patched.
+  # Above (in `forbidden-uses`), we restrict actions usage to organizations that we trust to have
+  # a baseline level of operational security.
+  # Our actions usage involves several long-term support branches and reusable workflows (which
+  # themselves use actions). For our threat model, we believe it is safer to limit actions usage to
+  # organizations we trust and immediately receive security patching across our many branches than
+  # it is to pin actions to a commit SHA.
+  unpinned-uses:
+    config:
+      policies:
+        canonical/*: ref-pin
+        actions/*: ref-pin

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,6 +1,6 @@
 name: mysql
 base: core24
-version: '8.0.45'
+version: '8.0.46'
 summary: MySQL server in a snap.
 description: |
   The MySQL software delivers a very fast, multithreaded, multi-user,
@@ -74,10 +74,10 @@ parts:
   packages-deb:
     plugin: nil
     stage-packages:
-      - mysql-server-8.0=8.0.45-0ubuntu0.24.04.1
+      - mysql-server=8.0.46-0ubuntu0.24.04.3
       - util-linux
     organize:
-      usr/share/doc/mysql-server-8.0/copyright: licenses/COPYRIGHT-mysql-server-8.0
+      usr/share/doc/mysql-server/copyright: licenses/COPYRIGHT-mysql-server
       usr/share/doc/util-linux/copyright: licenses/COPYRIGHT-util-linux
   snap-license:
     plugin: dump


### PR DESCRIPTION
This PR bumps the MySQL Server 8.0 binary to its latest version: `8.0.46`.

### Additional changes:
- Bumped all Data Platform workflows to version 49.
- Fixed the release workflow by quoting the track.