### PR TITLE
[MISC] (8.4/edge) Modernize snap testing

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -62,4 +62,5 @@ jobs:
           sudo iptables -P FORWARD ACCEPT
       - name: Run tests
         run: |
-          sudo --user "$USER" --preserve-env --preserve-env=PATH -- env -- PATH="$HOME/go/bin:$PATH" spread -v
+          SNAP_FILENAME=$(ls *.snap)
+          sudo --user "$USER" --preserve-env --preserve-env=PATH --preserve-env=CRAFT_ARTIFACT -- env -- PATH="$HOME/go/bin:$PATH" CRAFT_ARTIFACT="$(pwd)/$SNAP_FILENAME" spread -v

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -55,12 +55,12 @@ jobs:
           sudo snap install lxd
           sudo adduser "$USER" lxd
           # `newgrp` does not work in GitHub Actions; use `sudo --user` instead
-          sudo --user "$USER" --preserve-env --preserve-env=PATH -- env -- lxd waitready
-          sudo --user "$USER" --preserve-env --preserve-env=PATH -- env -- lxd init --auto
+          sudo --user "$USER" --preserve-env=PATH -- env -- lxd waitready
+          sudo --user "$USER" --preserve-env=PATH -- env -- lxd init --auto
           # Workaround for Docker & LXD on same machine
           sudo iptables -F FORWARD
           sudo iptables -P FORWARD ACCEPT
       - name: Run tests
         run: |
           SNAP_FILENAME=$(ls -- *.snap)
-          sudo --user "$USER" --preserve-env --preserve-env=CRAFT_ARTIFACT -- env -- CRAFT_ARTIFACT="$(pwd)/$SNAP_FILENAME" "$HOME/go/bin/spread" -v
+          sudo --user "$USER" --preserve-env=CRAFT_ARTIFACT -- env -- CRAFT_ARTIFACT="$(pwd)/$SNAP_FILENAME" "$HOME/go/bin/spread" -v

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -51,8 +51,7 @@ jobs:
           merge-multiple: true
       - name: Install dependencies
         run: |
-          sudo snap install snapcraft --classic
-          # lxd is necessary for spread
+          go install github.com/canonical/spread/cmd/spread@latest
           sudo snap install lxd
           sudo adduser "$USER" lxd
           # `newgrp` does not work in GitHub Actions; use `sudo --user` instead
@@ -63,4 +62,4 @@ jobs:
           sudo iptables -P FORWARD ACCEPT
       - name: Run tests
         run: |
-          sudo --user "$USER" --preserve-env --preserve-env=PATH -- env -- snapcraft test
+          sudo --user "$USER" --preserve-env --preserve-env=PATH -- env -- PATH="$HOME/go/bin:$PATH" spread -v

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -63,4 +63,4 @@ jobs:
       - name: Run tests
         run: |
           SNAP_FILENAME=$(ls *.snap)
-          sudo --user "$USER" --preserve-env --preserve-env=PATH --preserve-env=CRAFT_ARTIFACT -- env -- PATH="$HOME/go/bin:$PATH" CRAFT_ARTIFACT="$(pwd)/$SNAP_FILENAME" spread -v
+          sudo --user "$USER" --preserve-env --preserve-env=CRAFT_ARTIFACT -- env -- CRAFT_ARTIFACT="$(pwd)/$SNAP_FILENAME" "$HOME/go/bin/spread" -v

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -62,5 +62,5 @@ jobs:
           sudo iptables -P FORWARD ACCEPT
       - name: Run tests
         run: |
-          SNAP_FILENAME=$(ls *.snap)
+          SNAP_FILENAME=$(ls -- *.snap)
           sudo --user "$USER" --preserve-env --preserve-env=CRAFT_ARTIFACT -- env -- CRAFT_ARTIFACT="$(pwd)/$SNAP_FILENAME" "$HOME/go/bin/spread" -v

--- a/spread.yaml
+++ b/spread.yaml
@@ -3,7 +3,7 @@ project: mysql-snap
 path: /home/ubuntu/mysql-snap
 
 environment:
-  CRAFT_ARTIFACT: $(HOST:basename ./*.snap)
+  CRAFT_ARTIFACT: $(HOST:printenv CRAFT_ARTIFACT)
 
 backends:
   lxd:
@@ -17,7 +17,7 @@ suites:
     prepare: |
       apt --purge remove -y mysql* || true
     prepare-each: |
-      snap install "${SPREAD_PATH}/${CRAFT_ARTIFACT}" --dangerous --jailmode
+      snap install "${SPREAD_PATH}/$(basename "${CRAFT_ARTIFACT}")" --dangerous --jailmode
       until [ -S /var/snap/mysql/current/run/mysqld.sock ]; do
         echo "Waiting for mysqld.sock"
         sleep 1

--- a/spread.yaml
+++ b/spread.yaml
@@ -15,7 +15,7 @@ suites:
   spread/tests/:
     summary: General integration tests
     prepare: |
-      apt --purge remove -y mysql* || true
+      apt remove --purge --yes mysql* || true
     prepare-each: |
       snap install "${SPREAD_PATH}/$(basename "${CRAFT_ARTIFACT}")" --dangerous --jailmode
       until [ -S /var/snap/mysql/current/run/mysqld.sock ]; do

--- a/spread.yaml
+++ b/spread.yaml
@@ -1,8 +1,13 @@
 project: mysql-snap
 
+path: /home/ubuntu/mysql-snap
+
+environment:
+  CRAFT_ARTIFACT: $(HOST:basename ./*.snap)
+
 backends:
-  craft:
-    type: craft
+  lxd:
+    type: lxd
     systems:
       - ubuntu-24.04
 
@@ -12,7 +17,7 @@ suites:
     prepare: |
       apt --purge remove mysql*
     prepare-each: |
-      snap install "$CRAFT_ARTIFACT" --dangerous --jailmode
+      snap install "${SPREAD_PATH}/${CRAFT_ARTIFACT}" --dangerous --jailmode
       until [ -S /var/snap/mysql/current/run/mysqld.sock ]; do
         echo "Waiting for mysqld.sock"
         sleep 1

--- a/spread.yaml
+++ b/spread.yaml
@@ -15,7 +15,7 @@ suites:
   spread/tests/:
     summary: General integration tests
     prepare: |
-      apt --purge remove mysql*
+      apt --purge remove -y mysql* || true
     prepare-each: |
       snap install "${SPREAD_PATH}/${CRAFT_ARTIFACT}" --dangerous --jailmode
       until [ -S /var/snap/mysql/current/run/mysqld.sock ]; do

--- a/spread/tests/cli_mysqladmin/task.yaml
+++ b/spread/tests/cli_mysqladmin/task.yaml
@@ -3,8 +3,7 @@ summary: MySQL mysqladmin CLIs tests
 execute: |
   echo "Testing mysqladmin"
 
-  PASS=$(grep MY-010454 /var/snap/mysql/current/log/error.log | awk '{ print $NF }')
-  CMD="mysql.mysqladmin -u root --password=\"${PASS}\""
+  CMD="mysql.mysqladmin -u root"
 
   for subcmd in status version ping variables; do
     echo "mysqladmin ${subcmd}"

--- a/spread/tests/cli_mysqlcheck/task.yaml
+++ b/spread/tests/cli_mysqlcheck/task.yaml
@@ -3,8 +3,7 @@ summary: MySQL mysqlcheck CLI tests
 execute: |
   echo "Testing mysqlcheck"
 
-  PASS=$(grep MY-010454 /var/snap/mysql/current/log/error.log | awk '{ print $NF }')
-  CMD="mysql.mysqlcheck -u root --password=\"${PASS}\""
+  CMD="mysql.mysqlcheck -u root"
 
   ${CMD} --silent --extended --all-databases
 

--- a/spread/tests/cli_mysqlcli/task.yaml
+++ b/spread/tests/cli_mysqlcli/task.yaml
@@ -3,8 +3,7 @@ summary: MySQL mysql CLI tests
 execute: |
   echo "Testing mysql cli"
 
-  PASS=$(grep MY-010454 /var/snap/mysql/current/log/error.log | awk '{ print $NF }')
-  CMD="mysql -u root --password=\"${PASS}\""
+  CMD="mysql -u root"
 
   echo "Testing basic DML/DDL statments"
   ${CMD} -e "SHOW DATABASES;"

--- a/spread/tests/cli_mysqldump/task.yaml
+++ b/spread/tests/cli_mysqldump/task.yaml
@@ -3,9 +3,8 @@ summary: MySQL mysqldump CLI tests
 execute: |
   echo "Testing mysqldump"
 
-  PASS=$(grep MY-010454 /var/snap/mysql/current/log/error.log | awk '{ print $NF }')
-  CMD="mysql -u root --password=\"${PASS}\""
-  CMD_DUMP="mysql.mysqldump -u root --password=\"${PASS}\""
+  CMD="mysql -u root"
+  CMD_DUMP="mysql.mysqldump -u root"
 
   echo "Creating test db"
   ${CMD} -e "CREATE DATABASE test_db;"

--- a/spread/tests/cli_mysqlimport/task.yaml
+++ b/spread/tests/cli_mysqlimport/task.yaml
@@ -3,9 +3,8 @@ summary: MySQL mysqlimport CLI tests
 execute: |
   echo "Testing mysqlimport"
 
-  PASS=$(grep MY-010454 /var/snap/mysql/current/log/error.log | awk '{ print $NF }')
-  CMD="mysql -u root --password=\"${PASS}\""
-  CMD_IMPORT="mysql.mysqlimport -u root --password=\"${PASS}\""
+  CMD="mysql -u root"
+  CMD_IMPORT="mysql.mysqlimport -u root"
   IMPORT_FILE="/var/snap/mysql/common/test_table.csv"
 
   # allow file import

--- a/spread/tests/cli_mysqlshow/task.yaml
+++ b/spread/tests/cli_mysqlshow/task.yaml
@@ -3,9 +3,8 @@ summary: MySQL mysqlshow CLI tests
 execute: |
   echo "Testing mysqlshow"
 
-  PASS=$(grep MY-010454 /var/snap/mysql/current/log/error.log | awk '{ print $NF }')
-  CMD="mysql -u root --password=\"${PASS}\""
-  CMD_SHOW="mysql.mysqlshow -u root --password=\"${PASS}\""
+  CMD="mysql -u root"
+  CMD_SHOW="mysql.mysqlshow -u root"
 
   echo "Creating test db"
   ${CMD} -e "CREATE DATABASE test_db;"

--- a/spread/tests/cli_mysqlslap/task.yaml
+++ b/spread/tests/cli_mysqlslap/task.yaml
@@ -3,8 +3,7 @@ summary: MySQL mysqlslap CLI tests
 execute: |
   echo "Testing mysql slap"
 
-  PASS=$(grep MY-010454 /var/snap/mysql/current/log/error.log | awk '{ print $NF }')
-  CMD="mysql.mysqlslap -u root --password=\"${PASS}\""
+  CMD="mysql.mysqlslap -u root"
 
   ${CMD} -a --auto-generate-sql-execute-number=10
 

--- a/spread/tests/daemon_mysqld/task.yaml
+++ b/spread/tests/daemon_mysqld/task.yaml
@@ -2,8 +2,7 @@ summary: MySQL mysqld service tests
 
 execute: |
   echo "Testing service control"
-  PASS=$(grep MY-010454 /var/snap/mysql/current/log/error.log | awk '{ print $NF }')
-  CMD="mysql -u root --password=${PASS}"
+  CMD="mysql -u root"
 
   # Tests service control
   echo "Stopping mysql.mysqld"

--- a/spread/tests/smoke/task.yaml
+++ b/spread/tests/smoke/task.yaml
@@ -3,9 +3,8 @@ summary: MySQL SNAP smoke tests
 execute: |
   echo "MySQL Snap smoke tests"
 
-  PASS=$(grep MY-010454 /var/snap/mysql/current/log/error.log | awk '{ print $NF }')
   SNAP_VERSION=$(awk -F\' '/version/{print $2}' "${SPREAD_PATH}"/snap/snapcraft.yaml)
-  mysql --user=root --password="${PASS}" --execute="select @@version;" -E | \
+  mysql --user=root --execute="select @@version;" -E | \
     grep "^@@version: ${SNAP_VERSION:-error}"
 
   echo "Ensure all tools are present"

--- a/spread/tests/smoke/task.yaml
+++ b/spread/tests/smoke/task.yaml
@@ -4,7 +4,7 @@ execute: |
   echo "MySQL Snap smoke tests"
 
   PASS=$(grep MY-010454 /var/snap/mysql/current/log/error.log | awk '{ print $NF }')
-  SNAP_VERSION=$(awk -F\' '/version/{print $2}' "${PROJECT_PATH}"/snap/snapcraft.yaml)
+  SNAP_VERSION=$(awk -F\' '/version/{print $2}' "${SPREAD_PATH}"/snap/snapcraft.yaml)
   mysql --user=root --password="${PASS}" --execute="select @@version;" -E | \
     grep "^@@version: ${SNAP_VERSION:-error}"
 


### PR DESCRIPTION
While working on #34 , I noticed that our testing machinery had some quirks:

- After building the snap we were doing `snapcraft test`, which _builds the snap again_. There's no way around this, other than calling `spread` directly, which is what this PR does.
- `--password` was being ignored because the `install` hook installs and enables the `auth_socket` plugin

In addition, this PR reuses the `$CRAFT_ARTIFACT` variable so that users can (and in fact, _must_) determine the path of the `.snap` file to install.

I prefer to submit these test improvements in a separate PR.