### PR TITLE
[MISC] 8.4 - Prune unnecessary binaries

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -74,6 +74,17 @@ parts:
     stage-packages:
       - mysql-server=8.4.10-0ubuntu0.26.04.1
       - util-linux
+    prime:
+      # Mute lint by removing unnecessary MySQL libs
+      # which are shipped as APT packages
+      - -usr/lib/*/libicuio.so*
+      - -usr/lib/*/libicutest.so*
+      - -usr/lib/*/libicutu.so*
+      - -usr/lib/*/libprofiler.so*
+      - -usr/lib/*/libtcmalloc_*
+      - -usr/lib/*/libunwind-coredump.so*
+      - -usr/lib/*/libunwind-ptrace.so*
+      - -usr/lib/*/libunwind-x86_64.so*
     organize:
       usr/share/doc/mysql-server/copyright: licenses/COPYRIGHT-mysql-server
       usr/share/doc/util-linux/copyright: licenses/COPYRIGHT-util-linux

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -7,6 +7,11 @@ description: |
   and robust SQL (Structured Query Language) database server. MySQL
   Server is intended for mission-critical, heavy-load production
   systems as well as for embedding into mass-deployed software.
+title: MySQL
+contact: https://matrix.to/#/#charmhub-data-platform:ubuntu.com
+issues: https://github.com/canonical/mysql-snap/issues
+source-code: https://github.com/canonical/mysql-snap
+website: https://canonical.com/data/mysql
 
 grade: stable
 confinement: strict


### PR DESCRIPTION
This PR addresses issue https://github.com/canonical/mysql-snap/issues/36 by pruning the unnecessary binaries that are already installed as APT packages.

Now the snap build completes without warnings.