### PR TITLE
[DPE-10694] 8.4 - Define promote.yaml workflow

### DIFF
--- a/.github/release.yaml
+++ b/.github/release.yaml
@@ -1,0 +1,8 @@
+changelog:
+  categories:
+    - title: Features
+      labels:
+        - enhancement
+    - title: Bug fixes
+      labels:
+        - bug

--- a/.github/workflows/promote.yaml
+++ b/.github/workflows/promote.yaml
@@ -1,0 +1,37 @@
+# Copyright 2026 Canonical Ltd.
+# See LICENSE file for licensing details.
+name: Promote charm
+
+on:
+  workflow_dispatch:
+    inputs:
+      from-risk:
+        description: Promote from this Snapcraft risk
+        required: true
+        type: choice
+        options:
+          - edge
+          - beta
+          - candidate
+      to-risk:
+        description: Promote to this Snapcraft risk
+        required: true
+        type: choice
+        options:
+          - beta
+          - candidate
+          - stable
+
+jobs:
+  promote:
+    name: Promote snaps
+    uses: canonical/data-platform-workflows/.github/workflows/_promote_snaps.yaml@v50
+    with:
+      track: '8.4'
+      from-risk: ${{ inputs.from-risk }}
+      to-risk: ${{ inputs.to-risk }}
+      path-to-snap-directory: snap
+    secrets:
+      snap-store-token: ${{ secrets.SNAP_STORE_TOKEN }}
+    permissions:
+      contents: write  # Needed to edit GitHub releases


### PR DESCRIPTION
This PR defines a new `promote.yaml` GHA workflow using the recently published Data Platform workflows one.